### PR TITLE
Change the solver interface

### DIFF
--- a/lib/OptimalBranchingCore/Project.toml
+++ b/lib/OptimalBranchingCore/Project.toml
@@ -7,13 +7,11 @@ version = "0.1.1"
 BitBasis = "50ba71b6-fa0f-514d-ae9a-0916efc90dcf"
 HiGHS = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
-SCIP = "82193955-e24f-5292-bf16-6f2c5261a85f"
 
 [compat]
 BitBasis = "0.9"
 HiGHS = "1.12"
 JuMP = "1.23"
-SCIP = "0.11"
 julia = "1.10"
 
 [extras]

--- a/lib/OptimalBranchingCore/src/OptimalBranchingCore.jl
+++ b/lib/OptimalBranchingCore/src/OptimalBranchingCore.jl
@@ -1,6 +1,6 @@
 module OptimalBranchingCore
 
-using JuMP, HiGHS, SCIP
+using JuMP, HiGHS
 using BitBasis
 
 # logic expressions

--- a/lib/OptimalBranchingMIS/test/branch.jl
+++ b/lib/OptimalBranchingMIS/test/branch.jl
@@ -11,7 +11,7 @@ using Test, Random
             mis_exact = mis2(EliminateGraph(g))
             p = MISProblem(g)
 
-            for set_cover_solver in [IPSolver(10, false), LPSolver(10, false)], measure in [D3Measure(), NumOfVertices()], reducer in [NoReducer(), MISReducer(), XiaoReducer()], prune_by_env in [true, false], selector in [MinBoundarySelector(2), MinBoundaryHighDegreeSelector(2, 6, 0), MinBoundaryHighDegreeSelector(2, 6, 1)]
+            for set_cover_solver in [IPSolver(max_itr = 10, verbose = false), LPSolver(max_itr = 10, verbose = false)], measure in [D3Measure(), NumOfVertices()], reducer in [NoReducer(), MISReducer(), XiaoReducer()], prune_by_env in [true, false], selector in [MinBoundarySelector(2), MinBoundaryHighDegreeSelector(2, 6, 0), MinBoundaryHighDegreeSelector(2, 6, 1)]
                 branching_strategy = BranchingStrategy(; set_cover_solver, table_solver=TensorNetworkSolver(; prune_by_env), selector=selector, measure)
                 res = branch_and_reduce(p, branching_strategy, reducer, MaxSize)
                 res_count = branch_and_reduce(p, branching_strategy, reducer, MaxSizeBranchCount)


### PR DESCRIPTION
The `IPSolver` and `LPSolver` are changed, so that user can custom the optimizer.
The default choice is `HiGHS.jl`.

Here is an example:
```julia
ulia> using OptimalBranching, Graphs

julia> using OptimalBranching.OptimalBranchingCore

julia> using SCIP

julia> g = smallgraph(:tutte)
{46, 69} undirected simple Int64 graph

julia> branching_strategy = BranchingStrategy(table_solver = TensorNetworkSolver(), selector = MinBoundarySelector(2), measure=D3Measure(), set_cover_solver = IPSolver(optimizer = SCIP.Optimizer))
BranchingStrategy
├── table_solver - TensorNetworkSolver(true)
├── set_cover_solver - IPSolver(SCIP.Optimizer, 5, false)
├── selector - MinBoundarySelector(2)
└── measure - D3Measure()


julia> mis_size(g, bs = branching_strategy, reducer = MISReducer())
19
```