### PR TITLE
Improve the performance of generating candidate clauses

### DIFF
--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -61,7 +61,7 @@ tbl = BranchingTable(5, [
 
 Then, we generate the candidate clauses, which are the clauses forming the branching rule (a DNF formula).
 ```@repl quick-start
-candidates = collect(OptimalBranchingCore.candidate_clauses(tbl))
+candidates = OptimalBranchingCore.candidate_clauses(tbl)
 ```
 
 For each candidate clause, we calculate the size reduction of the problem after applying the clause. Here, we use a simple measure: counting the number of variables eliminated by the clause.

--- a/examples/rule_discovery.jl
+++ b/examples/rule_discovery.jl
@@ -30,7 +30,7 @@ function solve_opt_rule(branching_region, graph, vs)
     @info "the length of the truth_table after pruning irrelevant entries: $(length(tbl.table))"
 
     @info "generating candidate clauses..."
-    candidate_clauses = collect(OptimalBranchingMIS.OptimalBranchingCore.candidate_clauses(tbl))
+    candidate_clauses = OptimalBranchingMIS.OptimalBranchingCore.candidate_clauses(tbl)
     @info "the length of the candidate clauses: $(length(candidate_clauses))"
 
     @info "generating the optimal branching rule via set cover..."

--- a/lib/OptimalBranchingCore/src/branch.jl
+++ b/lib/OptimalBranchingCore/src/branch.jl
@@ -14,7 +14,7 @@ Generate an optimal branching rule from a given branching table.
 A [`OptimalBranchingResult`](@ref) object representing the optimal branching rule.
 """
 function optimal_branching_rule(table::BranchingTable, variables::Vector, problem::AbstractProblem, m::AbstractMeasure, solver::AbstractSetCoverSolver)
-    candidates = collect(candidate_clauses(table))
+    candidates = candidate_clauses(table)
     size_reductions = [measure(problem, m) - measure(first(apply_branch(problem, candidate, variables)), m) for candidate in candidates]
     return minimize_γ(table, candidates, size_reductions, solver; γ0=2.0)
 end

--- a/lib/OptimalBranchingCore/src/setcovering.jl
+++ b/lib/OptimalBranchingCore/src/setcovering.jl
@@ -175,9 +175,7 @@ function candidate_clauses(tbl::BranchingTable{INT}) where {INT}
     temp_clauses = [Clause(bmask(INT, 1:n), bs[i]) for i in 1:length(bs)]
     while !isempty(temp_clauses)
         c = pop!(temp_clauses)
-        if haskey(all_clauses, c)
-            continue
-        end
+        haskey(all_clauses, c) && continue
         all_clauses[c] = true
         for i in 1:length(bss)
             if !any(x->covered_by(x, c), bss[i])

--- a/lib/OptimalBranchingCore/test/setcovering.jl
+++ b/lib/OptimalBranchingCore/test/setcovering.jl
@@ -12,7 +12,7 @@ end
         [StaticBitVector([1, 0, 0, 1, 0])],
         [StaticBitVector([0, 0, 1, 0, 1])]
     ])
-    clauses = collect(OptimalBranchingCore.candidate_clauses(tbl))
+    clauses = OptimalBranchingCore.candidate_clauses(tbl)
     Δρ = [count_ones(c.mask) for c in clauses]
     result_ip = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, IPSolver(; max_itr = 10, verbose = false))
     result_lp = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, LPSolver(; max_itr = 10, verbose = false))
@@ -25,7 +25,7 @@ end
         [StaticBitVector([1, 1, 0, 1, 0])],
         [StaticBitVector([0, 0, 1, 0, 1])]
     ])
-    clauses = collect(OptimalBranchingCore.candidate_clauses(tbl))
+    clauses = OptimalBranchingCore.candidate_clauses(tbl)
     Δρ = [count_ones(c.mask) for c in clauses]
     result_ip = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, IPSolver(; max_itr = 10, verbose = false))
     result_lp = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, LPSolver(; max_itr = 10, verbose = false))
@@ -43,7 +43,7 @@ end
         [[1, 1, 0, 1, 0]],
         [[0, 0, 1, 0, 1]]
     ])
-    clauses = collect(OptimalBranchingCore.candidate_clauses(tbl))
+    clauses = OptimalBranchingCore.candidate_clauses(tbl)
     Δρ = [count_ones(c.mask) for c in clauses]
     result_ip = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, IPSolver(max_itr = 10, verbose = false))
     result_lp = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, LPSolver(max_itr = 10, verbose = false))
@@ -60,7 +60,7 @@ end
         [[1, 1, 0, 1, 0]],
         [[0, 0, 1, 1, 1]]
     ])
-    clauses = collect(OptimalBranchingCore.candidate_clauses(tbl))
+    clauses = OptimalBranchingCore.candidate_clauses(tbl)
     Δρ = [count_ones(c.mask) for c in clauses]
     result_ip = OptimalBranchingCore.minimize_γ(tbl, clauses, Δρ, IPSolver(max_itr = 10, verbose = false))
     @test OptimalBranchingCore.covered_by(tbl, result_ip.optimal_rule)


### PR DESCRIPTION
Before
```julia
julia> @btime OptimalBranchingMIS.OptimalBranchingCore.candidate_clauses(tbl);
  218.870 ms (5424242 allocations: 151.00 MiB)
```
After
```julia
julia> @btime OptimalBranchingMIS.OptimalBranchingCore.candidate_clauses(tbl) |> length
  42.664 ms (46 allocations: 1.76 MiB)
```